### PR TITLE
Disable caching for dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,16 @@ To create a new map, add another object to `MAP_LIBRARY` with an `id`, `name`, `
 2. Ensure the included `CNAME` file matches your custom domain (`td.trmp.dev`).
 3. Wait for GitHub Pages to build the site, then visit your configured domain.
 
+## Working in a dev environment without caching
+This repository is configured to avoid caching so you always receive a fresh copy when testing changes locally or on a staging URL:
+
+- `index.html` disables browser caching with `Cache-Control`, `Pragma`, and `Expires` meta tags.
+- The root-level `_headers` file sets `Cache-Control: no-store` for every asset when deploying to platforms that support static headers (such as Cloudflare Pages), ensuring CSS, JavaScript, and audio reload on every request.
+
+If additional cache busting is required on Cloudflare Pages:
+
+1. Open **Pages → [your project] → Settings → Caching** and set **Cache level** to **Bypass** with **Edge TTL** at `0` seconds.
+2. Add a Pages rule or response header transform that forces `Cache-Control: no-store` for the routes you are testing.
+3. When testing changes, also use the **Purge cache** button or the `wrangler pages deployment purge` command to clear any previously stored assets.
+
 Enjoy defending the vibe!

--- a/_headers
+++ b/_headers
@@ -1,0 +1,4 @@
+/*
+  Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate
+  Pragma: no-cache
+  Expires: 0

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>Tower Defense</title>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -75,6 +78,6 @@
   <audio id="explosionSound" src="sounds/explosion.mp3" preload="auto"></audio>
   <audio id="placeTowerSound" src="sounds/place.mp3" preload="auto"></audio>
   <audio id="gameOverSound" src="sounds/gameover.mp3" preload="auto"></audio>
-  <script src="game.js"></script>
+  <script src="game.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add HTTP-equiv directives to the HTML shell and defer script loading to avoid cached assets in development
- provide a `_headers` manifest so static hosts such as Cloudflare Pages send `Cache-Control: no-store`
- document recommended Cloudflare Pages caching settings for developers in the README

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d991bcaac88324bb678f1fe5ce5ded