### PR TITLE
Improve responsive layout and tower info positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,16 @@ To create a new map, add another object to `MAP_LIBRARY` with an `id`, `name`, `
 2. Ensure the included `CNAME` file matches your custom domain (`td.trmp.dev`).
 3. Wait for GitHub Pages to build the site, then visit your configured domain.
 
+## Working in a dev environment without caching
+This repository is configured to avoid caching so you always receive a fresh copy when testing changes locally or on a staging URL:
+
+- `index.html` disables browser caching with `Cache-Control`, `Pragma`, and `Expires` meta tags.
+- The root-level `_headers` file sets `Cache-Control: no-store` for every asset when deploying to platforms that support static headers (such as Cloudflare Pages), ensuring CSS, JavaScript, and audio reload on every request.
+
+If additional cache busting is required on Cloudflare Pages:
+
+1. Open **Pages → [your project] → Settings → Caching** and set **Cache level** to **Bypass** with **Edge TTL** at `0` seconds.
+2. Add a Pages rule or response header transform that forces `Cache-Control: no-store` for the routes you are testing.
+3. When testing changes, also use the **Purge cache** button or the `wrangler pages deployment purge` command to clear any previously stored assets.
+
 Enjoy defending the vibe!

--- a/_headers
+++ b/_headers
@@ -1,0 +1,4 @@
+/*
+  Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate
+  Pragma: no-cache
+  Expires: 0

--- a/game.js
+++ b/game.js
@@ -957,6 +957,44 @@ function clearStatusMessage() {
   if (el) el.textContent = '';
 }
 
+function positionTowerDetails(tower) {
+  const panel = document.getElementById('towerDetails');
+  const container = document.getElementById('gameContainer');
+  if (!panel || !container || !canvas || !tower) return;
+
+  const canvasRect = canvas.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  if (canvasRect.width === 0 || canvasRect.height === 0) return;
+
+  const scaleX = canvasRect.width / canvas.width;
+  const scaleY = canvasRect.height / canvas.height;
+  const anchorX = tower.centerX * scaleX;
+  const anchorYTop = tower.y * scaleY;
+  const anchorYBottom = (tower.y + tower.h) * scaleY;
+
+  const offsetX = canvasRect.left - containerRect.left;
+  const offsetY = canvasRect.top - containerRect.top;
+
+  const panelWidth = panel.offsetWidth;
+  const panelHeight = panel.offsetHeight;
+
+  let left = offsetX + anchorX - panelWidth / 2;
+  const minLeft = offsetX + 8;
+  const maxLeft = offsetX + canvasRect.width - panelWidth - 8;
+  left = Math.max(minLeft, Math.min(left, maxLeft));
+
+  let top = offsetY + anchorYTop - panelHeight - 18;
+  const minTop = offsetY + 8;
+  if (top < minTop) {
+    top = offsetY + anchorYBottom + 18;
+    const maxTop = offsetY + canvasRect.height - panelHeight - 8;
+    top = Math.max(minTop, Math.min(top, maxTop));
+  }
+
+  panel.style.left = left + 'px';
+  panel.style.top = top + 'px';
+}
+
 function selectTower(tower) {
   selectedTower = tower;
   const panel = document.getElementById('towerDetails');
@@ -964,6 +1002,8 @@ function selectTower(tower) {
 
   if (!tower) {
     panel.classList.add('hidden');
+    panel.style.left = '12px';
+    panel.style.top = '12px';
     document.getElementById('towerTitle').textContent = '';
     document.getElementById('towerDescription').textContent = '';
     document.getElementById('towerStats').textContent = '';
@@ -1001,6 +1041,8 @@ function selectTower(tower) {
 
   sellBtn.textContent = 'Sell (' + tower.getSellValue() + ')';
   sellBtn.disabled = false;
+
+  positionTowerDetails(tower);
 }
 
 function updateTowerDetails() {
@@ -1031,9 +1073,15 @@ function setPlacementMode(type) {
 
 function getMousePosition(e) {
   const rect = canvas.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    return { x: 0, y: 0 };
+  }
+
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
   return {
-    x: e.clientX - rect.left,
-    y: e.clientY - rect.top
+    x: (e.clientX - rect.left) * scaleX,
+    y: (e.clientY - rect.top) * scaleY
   };
 }
 
@@ -1364,6 +1412,10 @@ function init() {
   canvas.addEventListener('click', handleCanvasClick);
   canvas.addEventListener('mousemove', handleCanvasMove);
   canvas.addEventListener('mouseleave', () => { placementGhost = null; });
+
+  window.addEventListener('resize', () => {
+    if (selectedTower) positionTowerDetails(selectedTower);
+  });
 
   window.addEventListener('keydown', (e) => {
     if (e.code === 'Space') {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>Tower Defense</title>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -17,57 +20,58 @@
     </div>
   </div>
   
-  <div id="gameContainer">
-    <canvas id="gameCanvas" width="600" height="400"></canvas>
-    <div id="gameOverScreen" class="hidden">
-      <h2>Game Over</h2>
-      <p>Your final score: <span id="finalScore">0</span></p>
-      <button id="restartButton">Play Again</button>
-    </div>
-  </div>
-
-  <div id="hud">
-    <div class="hud-section">
-      <h2>Build</h2>
-      <div class="button-row">
-        <button id="placeBasicTower">Basic Tower (100)</button>
-        <button id="placeRapidTower">Rapid Tower (150)</button>
-        <button id="placeSniperTower">Sniper Tower (220)</button>
-        <button id="placeFrostTower">Frost Tower (170)</button>
+  <div id="gameLayout">
+    <div id="gameContainer">
+      <canvas id="gameCanvas" width="600" height="400"></canvas>
+      <div id="gameOverScreen" class="hidden">
+        <h2>Game Over</h2>
+        <p>Your final score: <span id="finalScore">0</span></p>
+        <button id="restartButton">Play Again</button>
+      </div>
+      <div id="towerDetails" class="panel hidden">
+        <h2 id="towerTitle"></h2>
+        <p id="towerDescription"></p>
+        <p id="towerStats"></p>
+        <p id="towerUpgradeInfo"></p>
+        <div class="button-row">
+          <button id="upgradeTowerButton">Upgrade</button>
+          <button id="sellTowerButton">Sell</button>
+        </div>
       </div>
     </div>
 
-    <div class="hud-section">
-      <h2>Game Status</h2>
-      <div class="status-row">
-        <button id="pauseButton">Pause</button>
-        <button id="nextWaveButton" class="primary">Start Next Wave</button>
-        <button id="changeMapButton">Change Map</button>
-        <span id="money">Money: 0</span>
-        <span id="lives">Lives: 0</span>
-        <span id="wave">Wave: 0</span>
-        <span id="score">Score: 0</span>
+    <div id="hud">
+      <div class="hud-section">
+        <h2>Build</h2>
+        <div class="button-row">
+          <button id="placeBasicTower">Basic Tower (100)</button>
+          <button id="placeRapidTower">Rapid Tower (150)</button>
+          <button id="placeSniperTower">Sniper Tower (220)</button>
+          <button id="placeFrostTower">Frost Tower (170)</button>
+        </div>
       </div>
-      <div class="info-row">
-        <span id="waveProgress">No wave in progress</span>
-        <span id="statusMessage"></span>
-      </div>
-      <div class="info-row">
-        <span id="mapName">Map: Not selected</span>
-        <span id="currentWaveInfo"></span>
-        <span id="nextWaveInfo"></span>
-      </div>
-    </div>
-  </div>
 
-  <div id="towerDetails" class="panel hidden">
-    <h2 id="towerTitle"></h2>
-    <p id="towerDescription"></p>
-    <p id="towerStats"></p>
-    <p id="towerUpgradeInfo"></p>
-    <div class="button-row">
-      <button id="upgradeTowerButton">Upgrade</button>
-      <button id="sellTowerButton">Sell</button>
+      <div class="hud-section">
+        <h2>Game Status</h2>
+        <div class="status-row">
+          <button id="pauseButton">Pause</button>
+          <button id="nextWaveButton" class="primary">Start Next Wave</button>
+          <button id="changeMapButton">Change Map</button>
+          <span id="money">Money: 0</span>
+          <span id="lives">Lives: 0</span>
+          <span id="wave">Wave: 0</span>
+          <span id="score">Score: 0</span>
+        </div>
+        <div class="info-row">
+          <span id="waveProgress">No wave in progress</span>
+          <span id="statusMessage"></span>
+        </div>
+        <div class="info-row">
+          <span id="mapName">Map: Not selected</span>
+          <span id="currentWaveInfo"></span>
+          <span id="nextWaveInfo"></span>
+        </div>
+      </div>
     </div>
   </div>
   
@@ -75,6 +79,6 @@
   <audio id="explosionSound" src="sounds/explosion.mp3" preload="auto"></audio>
   <audio id="placeTowerSound" src="sounds/place.mp3" preload="auto"></audio>
   <audio id="gameOverSound" src="sounds/gameover.mp3" preload="auto"></audio>
-  <script src="game.js"></script>
+  <script src="game.js" defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -14,6 +14,19 @@ h1 {
   text-shadow: 0 0 12px rgba(76, 175, 80, 0.4);
 }
 
+#gameLayout {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 24px;
+  margin: 24px auto 40px;
+  padding: 0 16px;
+  max-width: 1180px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .overlay {
   position: fixed;
   inset: 0;
@@ -100,18 +113,25 @@ h1 {
 }
 
 #gameContainer {
-  display: inline-block;
   position: relative;
-  margin-top: 20px;
+  flex: 1 1 600px;
+  width: min(100%, 600px);
+  max-width: 600px;
+  box-sizing: border-box;
   border: 2px solid #555;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
   background: #333;
-  border-radius: 10px;
-  overflow: hidden;
+  border-radius: 14px;
+  overflow: visible;
 }
 
 #gameCanvas {
   display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  border-radius: 12px;
+  image-rendering: pixelated;
 }
 
 #gameOverScreen {
@@ -131,8 +151,9 @@ h1 {
 }
 
 #hud {
-  max-width: 840px;
-  margin: 20px auto 0;
+  flex: 1 1 340px;
+  max-width: 420px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -184,29 +205,41 @@ h1 {
 }
 
 #towerDetails {
-  max-width: 840px;
-  margin: 10px auto 30px;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 10px;
-  padding: 18px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: min(260px, calc(100% - 24px));
+  background: rgba(10, 14, 20, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+  pointer-events: auto;
+  z-index: 25;
 }
 
 #towerDetails h2 {
   margin: 0 0 10px;
   text-align: center;
   color: #ffffff;
+  font-size: 18px;
 }
 
 #towerDetails p {
   margin: 6px 0;
   text-align: center;
   color: #e0f7fa;
+  font-size: 14px;
 }
 
 #towerDetails .button-row {
   margin-top: 12px;
+  display: flex;
+  gap: 10px;
+}
+
+#towerDetails .button-row button {
+  flex: 1 1 0;
 }
 
 button {
@@ -222,6 +255,11 @@ button {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
 }
 
+button:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
 button:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.4);
@@ -234,6 +272,18 @@ button.primary {
 button.primary:hover {
   background: #1e88e5;
 }
+
+#placeBasicTower { background: #3f51b5; }
+#placeBasicTower:hover { background: #3949ab; }
+
+#placeRapidTower { background: #f44336; }
+#placeRapidTower:hover { background: #e53935; }
+
+#placeSniperTower { background: #673ab7; }
+#placeSniperTower:hover { background: #5e35b1; }
+
+#placeFrostTower { background: #00acc1; }
+#placeFrostTower:hover { background: #0097a7; }
 
 button.disabled {
   opacity: 0.55;
@@ -274,7 +324,43 @@ button.active {
   border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-@media (max-width: 700px) {
-  #hud { padding: 0 10px; }
-  button { width: 100%; max-width: 240px; }
+@media (max-width: 1080px) {
+  #hud {
+    max-width: 520px;
+  }
+}
+
+@media (max-width: 900px) {
+  #gameLayout {
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+  }
+
+  #gameContainer,
+  #hud {
+    max-width: 640px;
+  }
+}
+
+@media (max-width: 720px) {
+  #hud {
+    max-width: 100%;
+  }
+
+  .button-row,
+  .status-row,
+  .info-row {
+    justify-content: center;
+    width: 100%;
+  }
+
+  button {
+    width: 100%;
+    max-width: none;
+  }
+
+  #towerDetails {
+    width: min(320px, calc(100% - 24px));
+  }
 }


### PR DESCRIPTION
## Summary
- wrap the playfield and HUD in a responsive layout and scale the canvas for different screen sizes
- float the tower details panel next to the selected tower and keep it positioned on resize
- align build button colors with their tower types and tighten mobile media queries

## Testing
- manual verification in browser (start level, place a tower, resize window)

------
https://chatgpt.com/codex/tasks/task_e_68d991bcaac88324bb678f1fe5ce5ded