### PR TITLE
Add Overpass Confluence map with intersecting paths

### DIFF
--- a/game.js
+++ b/game.js
@@ -136,6 +136,42 @@ const MAP_LIBRARY = [
       { row: 9, col: 7 }, { row: 9, col: 8 }, { row: 9, col: 9 }, { row: 9, col: 10 }, { row: 9, col: 11 },
       { row: 9, col: 12 }, { row: 9, col: 13 }
     ]
+  },
+  {
+    id: 'overpass-confluence',
+    name: 'Overpass Confluence',
+    description: 'Interlocking skyways where the route doubles back and crosses over itself.',
+    layout: [
+      [0,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [0,1,0,0,1,0,0,1,0,0,1,0,0,1,0],
+      [0,3,3,3,3,3,3,3,3,3,3,3,3,3,0],
+      [0,1,0,0,1,0,0,1,0,0,1,0,0,1,0],
+      [0,3,3,3,3,3,3,3,3,3,3,3,3,3,0],
+      [0,1,1,1,1,1,1,1,1,1,1,1,1,1,0],
+      [0,3,3,3,3,3,3,3,3,3,3,3,3,3,0],
+      [0,1,0,0,1,0,0,1,0,0,1,0,0,1,0],
+      [0,3,3,3,3,3,3,3,3,3,3,3,3,3,0],
+      [0,1,1,1,1,1,1,1,1,1,1,1,1,1,0]
+    ],
+    path: [
+      { row: 0, col: 1 }, { row: 1, col: 1 }, { row: 2, col: 1 }, { row: 3, col: 1 }, { row: 4, col: 1 },
+      { row: 5, col: 1 }, { row: 6, col: 1 }, { row: 7, col: 1 }, { row: 8, col: 1 }, { row: 9, col: 1 },
+      { row: 9, col: 2 }, { row: 9, col: 3 }, { row: 9, col: 4 }, { row: 9, col: 5 }, { row: 9, col: 6 },
+      { row: 9, col: 7 }, { row: 9, col: 8 }, { row: 9, col: 9 }, { row: 9, col: 10 }, { row: 9, col: 11 },
+      { row: 9, col: 12 }, { row: 9, col: 13 },
+      { row: 8, col: 13 }, { row: 7, col: 13 }, { row: 6, col: 13 }, { row: 5, col: 13 }, { row: 4, col: 13 },
+      { row: 3, col: 13 }, { row: 2, col: 13 }, { row: 1, col: 13 }, { row: 0, col: 13 },
+      { row: 0, col: 12 }, { row: 0, col: 11 }, { row: 0, col: 10 }, { row: 0, col: 9 }, { row: 0, col: 8 },
+      { row: 0, col: 7 }, { row: 1, col: 7 }, { row: 2, col: 7 }, { row: 3, col: 7 }, { row: 4, col: 7 },
+      { row: 5, col: 7 }, { row: 6, col: 7 }, { row: 7, col: 7 }, { row: 8, col: 7 }, { row: 9, col: 7 },
+      { row: 9, col: 6 }, { row: 9, col: 5 }, { row: 9, col: 4 }, { row: 9, col: 3 }, { row: 9, col: 2 },
+      { row: 9, col: 1 }, { row: 8, col: 1 }, { row: 7, col: 1 }, { row: 6, col: 1 }, { row: 5, col: 1 },
+      { row: 5, col: 2 }, { row: 5, col: 3 }, { row: 5, col: 4 }, { row: 5, col: 5 }, { row: 5, col: 6 },
+      { row: 5, col: 7 }, { row: 5, col: 8 }, { row: 5, col: 9 }, { row: 5, col: 10 }, { row: 5, col: 11 },
+      { row: 5, col: 12 }, { row: 5, col: 13 },
+      { row: 4, col: 13 }, { row: 3, col: 13 }, { row: 2, col: 13 }, { row: 1, col: 13 }, { row: 0, col: 13 },
+      { row: 0, col: 14 }
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- add the Overpass Confluence configuration with a city-grid themed layout
- define a looping path that doubles back across itself to deliver intersecting lanes

## Testing
- node --check game.js

------
https://chatgpt.com/codex/tasks/task_e_68dc62a40c788324a4776a731e213b27